### PR TITLE
feat: login시 토큰들 쿠키에 저장, 로그인 필요한 서비스 접근할 시 토큰 확인

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,17 @@
       "dependencies": {
         "@types/bcrypt": "^5.0.0",
         "@types/bcryptjs": "^2.4.2",
+        "@types/cookie-parser": "^1.4.3",
+        "@types/jsonwebtoken": "^9.0.2",
         "@types/mongoose": "^5.11.97",
         "@types/validator": "^13.7.17",
         "bcrypt": "^5.1.0",
         "bcryptjs": "^2.4.3",
+        "cookie-parser": "^1.4.6",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "helmet": "^7.0.0",
+        "jsonwebtoken": "^9.0.1",
         "mongoose": "^7.4.0",
         "validator": "^13.9.0"
       },
@@ -327,7 +331,6 @@
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
       "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-      "dev": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -337,16 +340,22 @@
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.3.tgz",
+      "integrity": "sha512-CqSKwFwefj4PzZ5n/iwad/bow2hTCh0FlNAeWLtQM3JA/NX/iYagIpWG2cf1bQKQ2c9gU2log5VUCrn7LDOs0w==",
+      "dependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/express": {
       "version": "4.17.17",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
       "integrity": "sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==",
-      "dev": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -358,7 +367,6 @@
       "version": "4.17.35",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.35.tgz",
       "integrity": "sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -369,8 +377,7 @@
     "node_modules/@types/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ==",
-      "dev": true
+      "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.12",
@@ -385,11 +392,18 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-drE6uz7QBKq1fYqqoFKTDRdFCPHd5TCub75BM+D+cMx7NU9hUz7SESLfC2fSCXVFMO5Yj8sOWHuGqPgjc+fz0Q==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
-      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
-      "dev": true
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
     },
     "node_modules/@types/mongoose": {
       "version": "5.11.97",
@@ -408,14 +422,12 @@
     "node_modules/@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-      "dev": true
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-      "dev": true
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "node_modules/@types/semver": {
       "version": "7.5.0",
@@ -428,7 +440,6 @@
       "version": "0.17.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.1.tgz",
       "integrity": "sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==",
-      "dev": true,
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"
@@ -438,7 +449,6 @@
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.2.tgz",
       "integrity": "sha512-J2LqtvFYCzaj8pVYKw8klQXrLLk7TBZmQ4ShlcdkELFKGwGMfevMLneMMRkMgZxotOD9wg497LpC7O8PcvAmfw==",
-      "dev": true,
       "dependencies": {
         "@types/http-errors": "*",
         "@types/mime": "*",
@@ -1146,6 +1156,11 @@
         "node": ">=14.20.1"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "node_modules/builtins": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
@@ -1319,6 +1334,26 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -1447,6 +1482,14 @@
       },
       "funding": {
         "url": "https://github.com/motdotla/dotenv?sponsor=1"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -2917,6 +2960,40 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.1.tgz",
+      "integrity": "sha512-K8wx7eJ5TPvEjuiVSkv167EVboBDv9PZdDoF7BgeQnBLVvZWW9clr2PsQHVJDTKaEIH5JBIwHujGcHp7GgI2eg==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash": "^4.17.21",
+        "ms": "^2.1.1",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/kareem": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
@@ -2952,6 +3029,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "nodemon --exec ts-node src/index.ts"
+    "dev": "nodemon --exec ts-node --files src/index.ts"
   },
   "author": "",
   "license": "ISC",
@@ -25,15 +25,19 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "@types/bcryptjs": "^2.4.2",
     "@types/bcrypt": "^5.0.0",
+    "@types/bcryptjs": "^2.4.2",
+    "@types/cookie-parser": "^1.4.3",
+    "@types/jsonwebtoken": "^9.0.2",
     "@types/mongoose": "^5.11.97",
     "@types/validator": "^13.7.17",
-    "bcryptjs": "^2.4.3",
     "bcrypt": "^5.1.0",
+    "bcryptjs": "^2.4.3",
+    "cookie-parser": "^1.4.6",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "helmet": "^7.0.0",
+    "jsonwebtoken": "^9.0.1",
     "mongoose": "^7.4.0",
     "validator": "^13.9.0"
   }

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -1,0 +1,9 @@
+import { IUser } from '../models/userModel';
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: IUser;
+    }
+  }
+}

--- a/src/controller/authController.ts
+++ b/src/controller/authController.ts
@@ -1,0 +1,83 @@
+import { NextFunction, Request, Response } from 'express';
+import * as authService from '../service/authService';
+
+export const join = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userData = req.body;
+    const newUser = await authService.join(userData);
+
+    res.status(201).json({
+      status: 'success',
+      data: {
+        user: newUser,
+      },
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const login = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const userData = req.body;
+    const { updatedUser, accessToken, refreshToken } = await authService.login(
+      userData,
+    );
+
+    res.cookie('accessToken', accessToken, {
+      expires: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      httpOnly: true,
+    });
+    res.cookie('refreshToken', refreshToken, {
+      expires: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      httpOnly: true,
+    });
+
+    res.status(200).json({
+      status: 'success',
+      data: {
+        user: updatedUser,
+        accessToken,
+        refreshToken,
+      },
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const logout = async (req: Request, res: Response) => {
+  await authService.logout(req.cookies.accessToken);
+  res.clearCookie('accessToken', { httpOnly: true });
+  res.clearCookie('refreshToken', { httpOnly: true });
+  res.status(200).json({ status: 'success' });
+};
+
+export const protect = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const { user, newAccessToken } = await authService.protect(
+      req.cookies.accessToken,
+      req.cookies.refreshToken,
+    );
+
+    req.user = user;
+    if (newAccessToken !== '') {
+      res.cookie('accessToken', newAccessToken, {
+        expires: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        httpOnly: true,
+      });
+    }
+
+    next();
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/controller/userController.ts
+++ b/src/controller/userController.ts
@@ -1,47 +1,14 @@
 import { NextFunction, Request, Response } from 'express';
 import * as userService from '../service/userService';
 
-
-export const join = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const newUser = await userService.join(req, res, next);
-
-    res.status(201).json({
-      status: 'success',
-      data: {
-        user: newUser,
-      },
-    });
-  } catch (err) {
-    next(err);
-  }
-};
-
-export const login = async (
-  req: Request,
-  res: Response,
-  next: NextFunction,
-) => {
-  try {
-    if (!(await userService.login(req, res, next))) {
-      throw { status: 401, message: 'Check your email or password' };
-    }
-
-    res.status(200).json({
-      status: 'success',
-    });
-  } catch (err) {
-    next(err);
-  }
-};
-
 export const getAllUsers = async (
   req: Request,
   res: Response,
   next: NextFunction,
 ) => {
   try {
-    const users = await userService.getAllUsers(req, res, next);
+    const users = await userService.getAllUsers();
+
     res.status(200).json({
       status: 'success',
       data: {
@@ -59,10 +26,14 @@ export const deleteUser = async (
   next: NextFunction,
 ) => {
   try {
-    const user = await userService.deleteUser(req, res, next);
+    const userId = req.params.id;
+    await userService.deleteUser(userId);
 
-    if (!user) {
-      throw { status: 404, message: 'User not found with this id' };
-    }
-  } catch (err) {}
+    res.status(204).json({
+      status: 'success',
+      data: null,
+    });
+  } catch (err) {
+    next(err);
+  }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,17 @@
 import express, { Request, Response } from 'express';
 import http from 'http';
-import router from './router/index';
 import helmet from 'helmet';
-import errorHandler from './middlewares/errorHandler';
 import dotenv from 'dotenv';
+import cookieParser from 'cookie-parser';
+import router from './router/index';
+import errorHandler from './middlewares/errorHandler';
 
 dotenv.config();
 const connectDB = async () => {
   const DbConnectionString = process.env.DBUrl || '';
   try {
     const db = await mongoose.connect(DbConnectionString);
-    console.log('Connected to database ${db.connection.host}');
+    console.log(`Connected to database ${db.connection.host}`);
   } catch (err) {
     console.error('Error: ${err.message}');
     process.exit(1);
@@ -24,6 +25,7 @@ const loadExpressApp = async () => {
 
   app.use(helmet());
   app.use(express.json());
+  app.use(cookieParser());
   app.enable('trust proxy');
 
   app.use(router);

--- a/src/models/userModel.ts
+++ b/src/models/userModel.ts
@@ -2,7 +2,7 @@ import { Schema, Model, model, Types } from 'mongoose';
 import validator from 'validator';
 import bcrypt from 'bcryptjs';
 
-export interface IUser {
+export interface IUser extends Document {
   _id: Types.ObjectId;
   password: string;
   studentId: number;
@@ -11,12 +11,14 @@ export interface IUser {
   name: string;
   nickname: string;
   role: string;
+  refreshToken: string;
   secondMajor: Types.ObjectId;
   passSemester: string;
   passDescription: string;
   passGPA: number;
   wannaSell: boolean;
   hopeMajors: Array<string> | null;
+  checkPassword: (userPassword: string) => Promise<boolean>;
 }
 
 const userSchema = new Schema<IUser>(
@@ -63,6 +65,11 @@ const userSchema = new Schema<IUser>(
         message: 'User role must be either: passer or candidate.',
       },
       required: [true, 'User must have a role.'],
+    },
+    refreshToken: {
+      type: String,
+      default: null,
+      // select: false,
     },
     // info of passer only
     secondMajor: {
@@ -138,7 +145,7 @@ userSchema.pre('save', async function (next) {
 });
 
 userSchema.methods.checkPassword = async function (userPassword: string) {
-  return await bcrypt.compare(userPassword, this.Password);
+  return await bcrypt.compare(userPassword, this.password);
 };
 
-export default model('User', userSchema);
+export default model<IUser>('User', userSchema);

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,14 +1,17 @@
 import express from 'express';
 import userRouter from './userRouter';
 import majorRouter from './majorRouter';
-import * as userController from '../controller/userController';
 import dashboardRouter from './dashboard';
 import postRouter from './postRouter';
+import * as authController from '../controller/authController';
 
 const router = express.Router();
 
-router.post('/join', userController.join);
-router.post('/login', userController.login);
+router.post('/join', authController.join);
+router.post('/login', authController.login);
+router.get('/logout', authController.logout);
+
+router.use(authController.protect);
 
 router.use('/user', userRouter);
 router.use('/post', postRouter);

--- a/src/service/authService.ts
+++ b/src/service/authService.ts
@@ -1,0 +1,170 @@
+import jwt from 'jsonwebtoken';
+import User, { IUser } from '../models/userModel';
+import Major, { IMajor } from '../models/majorModel';
+
+interface JwtPayload {
+  id: string;
+}
+
+const createToken = (user: IUser) => {
+  const accessToken = jwt.sign({ id: user._id }, process.env.JWT_SECRET_KEY!, {
+    expiresIn: '1h',
+  });
+
+  return accessToken;
+};
+
+const createRefreshToken = () => {
+  const refreshToken = jwt.sign({}, process.env.JWT_REFRESH_SECRET_KEY!, {
+    expiresIn: '30d',
+  });
+
+  return refreshToken;
+};
+
+const verifyToken = (accessToken: string) => {
+  try {
+    const { id } = jwt.verify(
+      accessToken,
+      process.env.JWT_SECRET_KEY!,
+    ) as JwtPayload;
+
+    return id;
+  } catch (err) {
+    return null;
+  }
+};
+
+const verifyRefreshToken = (refreshToken: string) => {
+  try {
+    jwt.verify(refreshToken, process.env.JWT_REFRESH_SECRET_KEY!);
+    return true;
+  } catch (err) {
+    return false;
+  }
+};
+
+export const join = async (userInfo: IUser) => {
+  const firstMajorName = userInfo.firstMajor;
+  const firstMajor: IMajor | null = await Major.findOne({
+    name: firstMajorName,
+  }).exec();
+  const secondMajorName = userInfo.secondMajor;
+
+  if (!secondMajorName) {
+    // candidate
+    const newUser = await User.create({
+      password: userInfo.password,
+      studentId: userInfo.studentId,
+      email: userInfo.email,
+      firstMajor: firstMajor!._id,
+      name: userInfo.name,
+      nickname: userInfo.nickname,
+      role: userInfo.role,
+      hopeMajors: userInfo.hopeMajors,
+    });
+    return newUser;
+  } else {
+    // passer
+    const secondMajor: IMajor | null = await Major.findOne({
+      name: secondMajorName,
+    }).exec();
+    const newUser = await User.create({
+      password: userInfo.password,
+      studentId: userInfo.studentId,
+      email: userInfo.email,
+      firstMajor: firstMajor!._id,
+      name: userInfo.name,
+      nickname: userInfo.nickname,
+      role: userInfo.role,
+      secondMajor: secondMajor!._id,
+      passSemester: userInfo.passSemester,
+      passDescription: userInfo.passDescription,
+      passGPA: userInfo.passGPA,
+      wannaSell: userInfo.wannaSell,
+    });
+    return newUser;
+  }
+};
+
+export const login = async (userData: IUser) => {
+  const { email, password } = userData;
+
+  if (!email || !password) {
+    throw { status: 400, message: '이메일 또는 비밀번호를 입력해주세요.' };
+  }
+
+  const user = await User.findOne({ email }).select('+password');
+
+  if (!user) {
+    throw { status: 401, message: '존재하지 않는 이메일입니다.' };
+  } else if (!(await user.checkPassword(password))) {
+    throw { status: 401, message: '비밀번호가 일치하지 않습니다.' };
+  }
+
+  const accessToken = createToken(user);
+  const refreshToken = createRefreshToken();
+
+  const updatedUser = await User.findByIdAndUpdate(
+    user._id,
+    { refreshToken },
+    {
+      new: true,
+    },
+  );
+
+  return { updatedUser, accessToken, refreshToken };
+};
+
+export const logout = async (accessToken: string) => {
+  if (accessToken) {
+    const { id } = jwt.decode(accessToken) as JwtPayload;
+    await User.findByIdAndUpdate(id, { refreshToken: null });
+  }
+};
+
+export const protect = async (accessToken: string, refreshToken: string) => {
+  // 1) 토큰이 있는지 확인, 없으면 로그인하도록.
+  if (!accessToken || !refreshToken) {
+    throw { status: 401, message: '로그인 후 재시도해주세요.' };
+  }
+
+  let newAccessToken: string = '';
+
+  // 2) accessToken이 유효한지 확인
+  const accessResult = verifyToken(accessToken);
+
+  if (accessResult === null) {
+    // 2 - 2) accessToken 만료되었음
+    // 3) user model에서 refreshToken 가져오고 유효한지 확인
+    const { id } = jwt.decode(accessToken) as JwtPayload;
+    const user = await User.findById(id);
+
+    if (!user || !user.refreshToken)
+      throw {
+        status: 400,
+        message: 'Invalid refresh token - id error',
+      };
+
+    if (verifyRefreshToken(user.refreshToken)) {
+      // 3 - 1) refreshToken 유효하다면 accessToken 새로 발급하고 user와 accessToken 리턴
+      newAccessToken = createToken(user);
+
+      return { user, newAccessToken };
+    } else {
+      // 3 - 2) refreshToken도 만료되었다면 새로 로그인하도록 throw error.
+      throw {
+        status: 400,
+        message: '세션이 만료되었습니다. 다시 로그인해주세요.',
+      };
+    }
+  } else {
+    // 2 - 1) accessToken이 유효하다면 유저 리턴
+    const user = await User.findById(accessResult);
+
+    // 실행되는 일 없을 것임, ts에러 떠서 추가.
+    if (!user) throw { status: 400, message: 'Bad Request' };
+
+    return { user, newAccessToken };
+  }
+};

--- a/src/service/userService.ts
+++ b/src/service/userService.ts
@@ -1,105 +1,19 @@
-import { NextFunction, Request, Response } from 'express';
 import User from '../models/userModel';
-import Major, { IMajor } from '../models/majorModel';
-import bcrypt from 'bcryptjs';
 
-export const join = async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const userInfo = req.body;
-    const firstMajorName = userInfo.firstMajor;
-    const firstMajor: IMajor | null = await Major.findOne({
-      name: firstMajorName,
-    }).exec();
-    const secondMajorName = userInfo.secondMajor;
+export const getAllUsers = async () => {
+  const users = await User.find()
+    .populate('firstMajor', 'name')
+    .populate('secondMajor', 'name');
 
-    if (!secondMajorName) {
-      // candidate
-      const newUser = await User.create({
-        password: userInfo.password,
-        studentId: userInfo.studentId,
-        email: userInfo.email,
-        firstMajor: firstMajor!._id,
-        name: userInfo.name,
-        nickname: userInfo.nickname,
-        role: userInfo.role,
-        hopeMajors: userInfo.hopeMajors,
-      });
-      return newUser;
-    } else {
-      // passer
-      const secondMajor: IMajor | null = await Major.findOne({
-        name: secondMajorName,
-      }).exec();
-      const newUser = await User.create({
-        password: userInfo.password,
-        studentId: userInfo.studentId,
-        email: userInfo.email,
-        firstMajor: firstMajor!._id,
-        name: userInfo.name,
-        nickname: userInfo.nickname,
-        role: userInfo.role,
-        secondMajor: secondMajor!._id,
-        passSemester: userInfo.passSemester,
-        passDescription: userInfo.passDescription,
-        passGPA: userInfo.passGPA,
-        wannaSell: userInfo.wannaSell,
-      });
-      return newUser;
-    }
-  } catch (err) {
-    next(err);
-  }
+  return users;
 };
 
-export const login = async (
-  req: Request,
-  res: Response,
-  next: NextFunction,
-) => {
-  try {
-    // FIXME: 1) T, F말고 user 보내주고 싶은데, 그러면 return false 대신 에러 생성해야 하는데 에러 생성이 안 돼서 일단 T, F
-    // 2) userModel에 checkPassword 함수를 만들었는데 user.checkPassword가 안 돼서 여기서 compare
-    // 3) user.password도 에러떠서 ! 붙였는데 이렇게 해도 되나
-    const { email, password } = req.body;
+export const deleteUser = async (userId: string) => {
+  const user = await User.findByIdAndDelete(userId);
 
-    if (!email || !password) return false;
-
-    const user = await User.findOne({ email }).select('+password');
-
-    if (!user || !(await bcrypt.compare(password, user.password!)))
-      return false;
-
-    return true;
-  } catch (err) {
-    next(err);
+  if (!user) {
+    throw { status: 404, message: 'User not found' };
   }
-};
 
-export const getAllUsers = async (
-  req: Request,
-  res: Response,
-  next: NextFunction,
-) => {
-  try {
-    const users = await User.find()
-      .populate('firstMajor', 'name')
-      .populate('secondMajor', 'name');
-    return users;
-  } catch (err) {
-    next(err);
-  }
-};
-
-export const deleteUser = async (
-  req: Request,
-  res: Response,
-  next: NextFunction,
-) => {
-  try {
-    const user = await User.findByIdAndDelete(req.params.id);
-
-    return user;
-  } catch (err) {
-    next(err);
-  }
+  return;
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
@@ -25,13 +25,16 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "commonjs" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    "typeRoots": [
+      "./src/@types",
+      "./node_modules/@types"
+    ] /* Specify multiple folders that act like './node_modules/@types'. */,
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
@@ -77,12 +80,12 @@
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
 
     /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
+    "strict": true /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
@@ -104,6 +107,6 @@
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
   }
 }


### PR DESCRIPTION
1. 로그인 시 accessToken과 refreshToken 만들어서 둘 다 쿠키에 저장하고, refreshToken은 추가로 유저 모델에 저장합니다.
.env 파일에 아래 이름으로 변수 추가해야합니다.

JWT_SECRET_KEY=my-great-long-secret-that-you-would-never-guess
JWT_REFRESH_SECRET_KEY=another-much-greater-and-longer-refresh-secret-that-you-would-again-never-guess

2. 유저 모델에 refreshToken 칼럼 추가

3. 라우터 폴더의 index 파일에서 user, post, dashboard, major 전에 'authController.protect' 적어놓아서 로그인해서 토큰 발급받아야지 접근 가능. 기능 확인해보려고 적은 거여서 지워도 됩니당.  앞으로 로그인 해야지만 접근 가능하도록 하고 싶으면 

router.route('/').get(**authController.protect**, majorController.getAllMajors)와 같이 protect를 먼저 부르면 됨. 그러면 이후에는 req.user로 현재 로그인한 유저 접근 가능하도록 했습니다. 이를 위해서 @types에서 Request 객체 확장.

4. protect안에서 accessToken 유효하면 바로 통과. accessToken 만료됐으면 유저 모델에서 refreshToken 찾고 유효한지 검사. 유효하다면 새로 accessToken 발급해서 쿠키에 저장해주고 통과. refreshToken도 만료됐다면 새로 로그인해달라는 메시지와 함께 에러 throw.

5. 로그아웃 시 현재 로그인 안 해있으면 아무 반응 없고 로그인해있으면 유저 모델에서 refreshToken을 null로 바꾸고, 두 개의 토큰 쿠키에서 삭제. 

accessToken 유효시간은 1시간, refreshToken 유효시간은 30일, 두 개의 토큰들 쿠키 만료 시간은 7일로 했는데 이상 있으면 알려주세여



