### PR TITLE
feat: 회원가입 인증 메일 발송

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@types/cookie-parser": "^1.4.3",
         "@types/jsonwebtoken": "^9.0.2",
         "@types/mongoose": "^5.11.97",
+        "@types/nodemailer": "^6.4.9",
         "@types/validator": "^13.7.17",
         "bcrypt": "^5.1.0",
         "bcryptjs": "^2.4.3",
@@ -23,6 +24,7 @@
         "helmet": "^7.0.0",
         "jsonwebtoken": "^9.0.1",
         "mongoose": "^7.4.0",
+        "nodemailer": "^6.9.4",
         "validator": "^13.9.0"
       },
       "devDependencies": {
@@ -418,6 +420,14 @@
       "version": "20.4.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.2.tgz",
       "integrity": "sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw=="
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.9.tgz",
+      "integrity": "sha512-XYG8Gv+sHjaOtUpiuytahMy2mM3rectgroNbs6R3djZEKmPNiIJwe9KqOJBGzKKnNZNKvnuvmugBgpq3w/S0ig==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
@@ -3398,6 +3408,14 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.4.tgz",
+      "integrity": "sha512-CXjQvrQZV4+6X5wP6ZIgdehJamI63MFoYFGGPtHudWym9qaEHDNdPzaj5bfMCvxG1vhAileSWW90q7nL0N36mA==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/cookie-parser": "^1.4.3",
     "@types/jsonwebtoken": "^9.0.2",
     "@types/mongoose": "^5.11.97",
+    "@types/nodemailer": "^6.4.9",
     "@types/validator": "^13.7.17",
     "bcrypt": "^5.1.0",
     "bcryptjs": "^2.4.3",
@@ -39,6 +40,7 @@
     "helmet": "^7.0.0",
     "jsonwebtoken": "^9.0.1",
     "mongoose": "^7.4.0",
+    "nodemailer": "^6.9.4",
     "validator": "^13.9.0"
   }
 }

--- a/src/controller/authController.ts
+++ b/src/controller/authController.ts
@@ -9,6 +9,7 @@ export const join = async (req: Request, res: Response, next: NextFunction) => {
     res.status(201).json({
       status: 'success',
       data: {
+        message: `${newUser.email}로 인증 링크를 보냈습니다. 이메일 인증을 하여 회원가입을 완료해주세요.`,
         user: newUser,
       },
     });
@@ -77,6 +78,20 @@ export const protect = async (
     }
 
     next();
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const certifyUser = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    await authService.certifyUser(req.params.certificateToken);
+
+    res.redirect('/');
   } catch (err) {
     next(err);
   }

--- a/src/models/userModel.ts
+++ b/src/models/userModel.ts
@@ -1,5 +1,4 @@
 import { Schema, Model, model, Types } from 'mongoose';
-import validator from 'validator';
 import bcrypt from 'bcryptjs';
 
 export interface IUser extends Document {
@@ -12,6 +11,7 @@ export interface IUser extends Document {
   nickname: string;
   role: string;
   refreshToken: string;
+  certificate: string;
   secondMajor: Types.ObjectId;
   passSemester: string;
   passDescription: string;
@@ -40,7 +40,10 @@ const userSchema = new Schema<IUser>(
       required: [true, 'User must have an email address.'],
       unique: true,
       trim: true,
-      validate: validator.isEmail,
+      match: [
+        /^[a-zA-Z0-9._%+-]+@korea\.ac\.kr$/,
+        'Please fill a valid korea university email address',
+      ],
     },
     firstMajor: {
       type: Schema.Types.ObjectId,
@@ -69,7 +72,12 @@ const userSchema = new Schema<IUser>(
     refreshToken: {
       type: String,
       default: null,
-      // select: false,
+      select: false,
+    },
+    certificate: {
+      type: String,
+      enum: ['pending', 'active'],
+      default: 'pending',
     },
     // info of passer only
     secondMajor: {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -10,6 +10,11 @@ const router = express.Router();
 router.post('/join', authController.join);
 router.post('/login', authController.login);
 router.get('/logout', authController.logout);
+router.get('/certify/:certificateToken', authController.certifyUser);
+
+router.get('/', (req, res) => {
+  res.send('Hello World!');
+});
 
 router.use(authController.protect);
 
@@ -17,9 +22,5 @@ router.use('/user', userRouter);
 router.use('/post', postRouter);
 router.use('/dashboard', dashboardRouter);
 router.use('/major', majorRouter);
-
-router.get('/', (req, res) => {
-  res.send('Hello World!');
-});
 
 export default router;

--- a/src/router/userRouter.ts
+++ b/src/router/userRouter.ts
@@ -3,6 +3,7 @@ import * as userController from '../controller/userController';
 
 const userRouter = express.Router();
 
-userRouter.route('/').get(userController.getAllUsers);
+userRouter.get('/', userController.getAllUsers);
+userRouter.delete('/:id', userController.deleteUser);
 
 export default userRouter;

--- a/src/utils/email.ts
+++ b/src/utils/email.ts
@@ -1,0 +1,31 @@
+import nodemailer from 'nodemailer';
+
+export const sendAuthEmail = async (
+  name: string,
+  emailTo: string,
+  certificateToken: string,
+) => {
+  const smtpTransport = nodemailer.createTransport({
+    service: 'gmail',
+    auth: {
+      user: process.env.EMAIL_USER,
+      pass: process.env.EMAIL_PASS,
+    },
+  });
+
+  const mailOptions = {
+    from: process.env.EMAIL_USER,
+    to: emailTo,
+    subject: 'KUPPLY 회원가입 인증 메일',
+    html: `<h1>이메일 인증</h1>
+        <h2>안녕하세요 ${name}님</h2>
+        <p>KUPPLY에 회원가입해주셔서 감사합니다. 아래 링크로 이동해 회원가입을 완료해주세요!</p>
+        <p>만약에 실수로 요청하셨거나, 본인이 요청하지 않았다면, 이 메일을 무시하세요.</p>
+        <a href=http://localhost:${
+          process.env.PORT || 8080
+        }/certify/${certificateToken}> 계속하기</a>
+        </div>`,
+  };
+
+  await smtpTransport.sendMail(mailOptions);
+};

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,0 +1,61 @@
+import jwt from 'jsonwebtoken';
+import User, { IUser } from '../models/userModel';
+
+interface JwtPayload {
+  id: string;
+}
+
+export const createToken = (user: IUser) => {
+  const accessToken = jwt.sign({ id: user._id }, process.env.JWT_SECRET_KEY!, {
+    expiresIn: '1h',
+  });
+
+  return accessToken;
+};
+
+export const createRefreshToken = () => {
+  const refreshToken = jwt.sign({}, process.env.JWT_REFRESH_SECRET_KEY!, {
+    expiresIn: '30d',
+  });
+
+  return refreshToken;
+};
+
+export const createCertificateToken = (user: IUser) => {
+  const accessToken = jwt.sign(
+    { id: user._id },
+    process.env.JWT_CERTIFICATE_SECRET_KEY!,
+    {
+      expiresIn: '1h',
+    },
+  );
+
+  return accessToken;
+};
+
+export const verifyToken = (accessToken: string) => {
+  try {
+    const { id } = jwt.verify(
+      accessToken,
+      process.env.JWT_SECRET_KEY!,
+    ) as JwtPayload;
+
+    return id;
+  } catch (err) {
+    return null;
+  }
+};
+
+export const verifyRefreshToken = (refreshToken: string) => {
+  try {
+    jwt.verify(refreshToken, process.env.JWT_REFRESH_SECRET_KEY!);
+    return true;
+  } catch (err) {
+    return false;
+  }
+};
+
+export const decodeToken = (accessToken: string) => {
+  const { id } = jwt.decode(accessToken) as JwtPayload;
+  return id;
+};


### PR DESCRIPTION
회원가입 시 이메일 인증을 위해서 인증 메일 발송하는 기능 추가했습니다.

gmail로 해서 구글 계정 설정에서 보안에서 2단계 인증 사용 허용하고, 앱 비밀번호 새로 발급받아야 합니다.
.env 파일에
EMAIL_USER=jhyoon1607@gmail.com
EMAIL_PASS=knthdbxsytlmyzjl
이런 식으로 사용한 메일이랑 발급받은 비밀번호 사용하면 됩니다.

인증된 유저인지 기록하기 위해서 유저모델에 
certificate: {
      type: String,
      enum: ['pending', 'active'],
      default: 'pending',
} 을 추가했습니다.

회원가입 할 때 유저 id로 jwt 토큰을 발행하고 그 토큰을 이메일로 '/certify/:certificateToken' url을 보내고 이 링크에 접근하면 토큰을 decode해서  유저 확인한 후 그 유저의 'certificate'을 'active'로 바꿉니다.
그리고 '/'으로 redirect하게 했습니다. 

이제 로그인할 때 이메일 인증을 하지 않은(certificate이 pending인) 유저가 로그인하면 
throw {
      status: 401,
      message: '이메일을 인증하여 회원가입을 완료하시고 다시 로그인해 주세요.',
}; 다음과 같은 에러를 발생시킵니다.

![image](https://github.com/DevKor-github/kupply-back/assets/88926099/755115bb-0ccc-4acc-ac5c-a67b73c82b20)

이메일을 지금은 다음과 같이 보내는데 양식 같은 거는 논의를 해봐야 할듯..